### PR TITLE
Allows for listing items to indicate the escrow release type.

### DIFF
--- a/src/format-validators/mpa_listing_add.ts
+++ b/src/format-validators/mpa_listing_add.ts
@@ -68,7 +68,7 @@ export class FV_MPA_LISTING {
             if (isObject(information.location)) {
                 const location = information.location;
 
-                if (location && !isCountry(location.country)) {
+                if (location && location.country && !isCountry(location.country)) {
                     throw new Error('action.item.information.location.country: not a country');
                 }
 

--- a/src/interfaces/omp-enums.ts
+++ b/src/interfaces/omp-enums.ts
@@ -37,6 +37,14 @@ export enum EscrowType {
 }
 
 /**
+ * Different escrow release address types
+ */
+export enum EscrowReleaseType {
+    BLIND = 'blind',
+    ANON = 'anon'
+}
+
+/**
  * Protocols supported by the protocol.
  */
 export enum MessagingProtocol {

--- a/src/interfaces/omp.ts
+++ b/src/interfaces/omp.ts
@@ -6,7 +6,7 @@
 
 import { Prevout, CryptoAddress, Cryptocurrency, ISignature, ToBeOutput, EphemeralKey, Fiatcurrency, ToBeBlindOutput, BlindPrevout } from './crypto';
 import { DSN, ContentReference } from './dsn';
-import { MPAction, SaleType, EscrowType, MessagingProtocol } from './omp-enums';
+import { MPAction, SaleType, EscrowType, EscrowReleaseType, MessagingProtocol } from './omp-enums';
 import { KVS } from './common';
 
 
@@ -331,6 +331,7 @@ export interface EscrowConfig {
     type: EscrowType;
     ratio: EscrowRatio;
     secondsToLock: number;
+    releaseType?: EscrowReleaseType;
 }
 
 /**


### PR DESCRIPTION
Defaults to a 'blind' type output if not specified.

** Also includes the fix that was done for the v0.1.113 release that was not included in the master branch.